### PR TITLE
Added meta tag for mobile optimized scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>STRML: Projects and Work</title>
     <style id="style-tag"></style>
     <script src="dist/app.js"></script>


### PR DESCRIPTION
Unless intentional, when viewing on smaller devices there are no viewport rules to control zooming. This means that text is currently scaling (tiny) against the width of the device. I added a meta tag inside your head tag, if you intended it to be optimised for mobile too