### PR TITLE
Add scroll Compatibility with mobile devices

### DIFF
--- a/app.js
+++ b/app.js
@@ -196,22 +196,33 @@ function createWorkBox() {
 
   // flippy floppy
   let flipping = 0;
+  let flipped = false;
+  let half = (workEl.scrollHeight - workEl.clientHeight) / 2;
+  let pastHalf = false;
   require('mouse-wheel')(workEl, async function(dx, dy) {
     if (flipping) return;
-    let flipped = workEl.classList.contains('flipped');
-    let half = (workEl.scrollHeight - workEl.clientHeight) / 2;
-    let pastHalf = flipped ? workEl.scrollTop < half : workEl.scrollTop > half;
-
-    // If we're past half, flip the el.
-    if (pastHalf) {
-      workEl.classList.toggle('flipped');
-      flipping = true;
-      await Promise.delay(500);
-      workEl.scrollTop = flipped ? 0 : 9999;
-      flipping = false;
-    }
+    flipped = workEl.classList.contains('flipped');
+    half = (workEl.scrollHeight - workEl.clientHeight) / 2;
+    pastHalf = flipped ? workEl.scrollTop < half : workEl.scrollTop > half;
 
     // Scroll. If we've flipped, flip the scroll direction.
     workEl.scrollTop += (dy * (flipped ? -1 : 1));
   }, true);
+
+  // Put the checker for scrolling in another scroll listener,
+  // so the flip event can be triggered correctly in mobile devices
+  workEl.addEventListener('scroll', async function(event) {
+    if (pastHalf) {
+      flipping = true
+      workEl.classList.toggle('flipped')
+      await Promise.delay(500)
+      workEl.scrollTop = flipped ? 0 : 9999
+
+      // Sometimes I found if user continously scroll during flipping, 
+      // the workEl will mistakely flip twice, so I manually set passHalf
+      // to false to solve it
+      pastHalf = false   
+      flipping = false
+    }
+  })
 }

--- a/app.js
+++ b/app.js
@@ -197,13 +197,8 @@ function createWorkBox() {
   // flippy floppy
   let flipping = 0;
   let flipped = false;
-  let half = (workEl.scrollHeight - workEl.clientHeight) / 2;
-  let pastHalf = false;
   require('mouse-wheel')(workEl, async function(dx, dy) {
     if (flipping) return;
-    flipped = workEl.classList.contains('flipped');
-    half = (workEl.scrollHeight - workEl.clientHeight) / 2;
-    pastHalf = flipped ? workEl.scrollTop < half : workEl.scrollTop > half;
 
     // Scroll. If we've flipped, flip the scroll direction.
     workEl.scrollTop += (dy * (flipped ? -1 : 1));
@@ -212,6 +207,9 @@ function createWorkBox() {
   // Put the checker for scrolling in another scroll listener,
   // so the flip event can be triggered correctly in mobile devices
   workEl.addEventListener('scroll', async function(event) {
+    flipped = workEl.classList.contains('flipped');
+    let half = (workEl.scrollHeight - workEl.clientHeight) / 2;
+    let pastHalf = flipped ? workEl.scrollTop < half : workEl.scrollTop > half;
     if (pastHalf) {
       flipping = true
       workEl.classList.toggle('flipped')


### PR DESCRIPTION
Hi Samuel,
I love this project very much and thus introduced it to many friends of me. 
This afternoon, when I try to show your page for one of my friends using my iPhone, I found the workEl cannot flip in my phone at all. So I checked the code and found that it is caused because the node module 'mouse-wheel' didn't listen to the touch and drag event on mobile devices like iPhone.
Therefore, I made a small change to the code which adds a new scroll listener to flip the workEl, thus workEl can flip in mobile devices now.

Thank you~!